### PR TITLE
Add self-hosted option to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
       # Required.
       dep: deploy
 
+      # Option to skip over the SSH setup/configuration
+      # Self hosted runners don't need the SSH configuration or the SSH agent to be started
+      self-hosted: false
+
       # Private key for connecting to remote hosts. To generate private key:
       # `ssh-keygen -o -t rsa -C 'action@deployer.org'`.
       # Optional.

--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,11 @@ inputs:
     required: true
     description: The command.
 
+  self-hosted:
+    required: false
+    default: 'false'
+    description: Whether the action is running on a self-hosted runner.
+
   private-key:
     required: false
     default: ''

--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ void async function main() {
 }()
 
 async function ssh() {
+  if (core.getBooleanInput('self-hosted')) {
+    return;
+  }
+
   let sshHomeDir = `${process.env['HOME']}/.ssh`
 
   if (!fs.existsSync(sshHomeDir)) {


### PR DESCRIPTION
+ This skips over the SSH configuration part of the action.
+ This is because self-hosted runners would typically have SSH already running causing ssh-agent command to throw an error (process already exists/port in use)